### PR TITLE
Fix the browse path

### DIFF
--- a/phabricator.py
+++ b/phabricator.py
@@ -60,7 +60,7 @@ class PhabricatorOpenCommand(sublime_plugin.WindowCommand):
         escaped_branch = quote(quote(git_branch, safe=''), safe='')
 
         # Run `arc browse` and dump the output to the console
-        browse_path = '{0}${1}'.format(filename, lines)
+        browse_path = '{0}:{1}'.format(filename, lines)
         arc_args = [settings.get('arc_path', 'arc'), 'browse', browse_path, '--branch', escaped_branch]
         arc_child = subprocess.Popen(
             arc_args, cwd=filedir,


### PR DESCRIPTION
We were using `<filename>$<lines>` with `arc browse` which used to kinda work.
After https://secure.phabricator.com/T5781 this broke, so now we should use `<filename>:<lines>`
